### PR TITLE
Implement adblocking and WAN DHCP; move vars into files; update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Internet should be free. Pretty simple, no?
  - clone the ansible codebase to apply to a raspberry pi/similar
  - once deployed, an AP called "Internet should be free" is opened up, serving internet from the Ethernet port
  - offers DHCP lease, DNS and NAT/gateway services
+ - blocks ads via `/etc/hosts` thanks to [https://github.com/StevenBlack/hosts/]
 
 # install:
 ```
-# modify 'hosts' file
-apt-get install sshpass libssl-dev libffi-dev
+# copy 'example_hosts' to  'hosts' and modify it (warning: the default is set to localhost!)
+# modify 'vars/default.yml'
+sudo apt-get install sshpass libssl-dev libffi-dev python-virtualenv
 virtualenv venv
 source venv/bin/activate
 pip install ansible
@@ -19,14 +21,13 @@ ansible-playbook allinone.yml
 ```
 
 # notes:
- - hosts are expected to be running Debian and to have Broadcom wireless drivers
- - you must supply your own "hosts" file in the root of this directory; an example hosts file that configures 127.0.0.1 as an "allinone" host is provided as `example_hosts`. ansible supports provisioning many hosts at once - if you have 5 Pis, put their IP addresses here!
- - you must create a user named "deploy" that can sudo, or change the username value in the `allinone.yml` file
- - you must setup the WAN-side with static addresses prior to deployment; this will change in a future release.
+ - hosts are expected to be running Debian and to have AP-capable wireless drivers
+ - you must supply your own "hosts" file for Ansible in the root of this directory; an example hosts file that configures 127.0.0.1 as an "allinone" host is provided as `example_hosts`. ansible supports provisioning many hosts at once - if you have 5 Pis, put their IP addresses here!
+ - if you do not want to use your own username to log into the targets, set the `-u` flag when running `ansible-playbook`
+ - the default is to set dynamic WAN addresses with DHCP; however, changing that is simple in the `allinone.yml` file - see the lan side example for a static config.
  - initial implementation doesn't attempt to secure the gateway very much; it also deserves to have firewall rules split out into a less-messy config
 
 # wishlist:
- - implement ad-blocking at the DNS server a-la PiHole
+ - organize playbook into actual roles to facilitate reuse
  - before routing traffic publicly, tell the user "internet should be free" and to click "i accept" (propaganda garden)
  - implement QoS to allow userbase to scale well and prioritize non-commercial/latency-sensitive uses
- - implement WAN-side as DHCP

--- a/allinone.yml
+++ b/allinone.yml
@@ -1,22 +1,22 @@
 ---
 - hosts: allinone
-  remote_user: deploy
   become: yes
+  vars_files:
+    - vars/default.yml
   tasks:
     - include: roles/common/tasks/base.yml
     - include: roles/common/tasks/network-interfaces.yml
-    - include: roles/common/tasks/static-interface.yml interface='eth0' address='192.168.1.12' netmask='255.255.255.0' gateway='192.168.1.254' custom='metric 1'
-    - include: roles/common/tasks/static-interface.yml interface='wlan0' address='172.24.69.1' netmask='255.255.255.0' custom='metric 10'
+    - include: roles/common/tasks/dhcp-interface.yml interface={{ wan_interface }}
+    - include: roles/common/tasks/static-interface.yml interface={{ lan_interface }} address={{ lan_address }} netmask={{ lan_netmask }}
     - include: roles/common/tasks/ufw.yml
-    - include: roles/common/tasks/ufw_rule.yml rule=allow src="192.168.1.0/24"
-    - include: roles/common/tasks/ufw_rule.yml rule=allow insert=1 src="172.24.69.0/24" dest="172.24.69.0/24"
-    - include: roles/common/tasks/ufw_rule.yml rule=deny insert=2 src="172.24.69.0/24" dest="192.168.0.0/16"
-    - include: roles/common/tasks/ufw_rule.yml rule=deny insert=3 src="172.24.69.0/24" dest="10.0.0.0/8"
-    - include: roles/common/tasks/ufw_rule.yml rule=deny insert=4 src="172.24.69.0/24" dest="172.16.0.0/12"
-    - include: roles/common/tasks/ufw_rule.yml rule=allow insert=5 src="172.24.69.0/24"
-    - include: roles/ap/tasks/main.yml ap_interface=wlan0 ssid='Internet should be free' channel=1
-    - include: roles/dnsdhcp/tasks/main.yml lan_interface=wlan0 lan_address=172.24.69.1 dhcp_range_string=172.24.69.2,172.24.69.254,1h upstream_dns_server=192.168.1.254
-    - include: roles/gateway/tasks/main.yml nat_range="172.24.69.0/24" upstream_dev="eth0"
+    - include: roles/common/tasks/ufw_rule.yml rule=allow src={{ lan_network }} dest={{ lan_network }}
+    - include: roles/common/tasks/ufw_rule.yml rule=deny src={{ lan_network }} dest="192.168.0.0/16"
+    - include: roles/common/tasks/ufw_rule.yml rule=deny src={{ lan_network }} dest="10.0.0.0/8"
+    - include: roles/common/tasks/ufw_rule.yml rule=deny src={{ lan_network }} dest="172.16.0.0/12"
+    - include: roles/common/tasks/ufw_rule.yml rule=allow src={{ lan_network }}
+    - include: roles/ap/tasks/main.yml
+    - include: roles/dnsdhcp/tasks/main.yml
+    - include: roles/gateway/tasks/main.yml
   handlers:
     - include: roles/common/handlers/main.yml
     - include: roles/ap/handlers/main.yml

--- a/roles/ap/templates/hostapd.conf.j2
+++ b/roles/ap/templates/hostapd.conf.j2
@@ -1,4 +1,4 @@
-interface={{ ap_interface }}
+interface={{ lan_interface }}
 
 # Use the nl80211 driver with the brcmfmac driver; assumptions cuz raspberry pi
 driver=nl80211
@@ -7,9 +7,9 @@ driver=nl80211
 ssid={{ ssid }}
 
 # Use the 2.4GHz band
-hw_mode=g
+hw_mode={{ hw_mode }}
 
-# Use channel {{ channel }} (0 is the same as acs_survey, an automatic channel pick mode)
+# Use channel {{ channel }}
 channel={{ channel }}
 
 # Enable 802.11n
@@ -32,10 +32,7 @@ ignore_broadcast_ssid=1
 {% if password is defined %}
 # Set up WPA
 wpa=2
-wpa_key_mgmt=WPA-PSK-SHA256
+wpa_key_mgmt=WPA-PSK
 wpa_passphrase={{ password }}
-wpa_ptk_rekey=60
-wpa_gmk_rekey=3600
-wpa_pairwise=CCMP
 rsn_pairwise=CCMP
 {% endif %}

--- a/roles/common/tasks/adblock.yml
+++ b/roles/common/tasks/adblock.yml
@@ -1,0 +1,9 @@
+---
+# We flush handlers to make sure our network config has internet connectivity
+- meta: flush_handlers
+- name: Download adblocked /etc/hosts file
+  get_url:
+    url: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+    dest: /etc/hosts
+    force: yes
+    backup: yes

--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -1,10 +1,10 @@
 ---
 # what can I say, I'm opinionated
-- name: install tmux
-  package: name=tmux state=latest
-- name: install vim
-  package: name=vim state=latest
-- name: install dstat
-  package: name=dstat state=latest
-- name: install curl
-  package: name=curl state=latest
+- name: install base packages
+  package: name={{ item }} state=latest
+  with_items:
+    - tmux
+    - vim
+    - dstat
+    - curl
+    - isc-dhcp-client

--- a/roles/common/tasks/static-interface.yml
+++ b/roles/common/tasks/static-interface.yml
@@ -5,5 +5,6 @@
     - restart networking
 - name: disable dhcp on interface {{ interface }}
   lineinfile: dest=/etc/dhcpcd.conf state=present regexp="^denyinterfaces {{ interface }}$" insertbefore='^interface' line="denyinterfaces {{ interface }}"
+  ignore_errors: True
   notify:
     - restart dhcpcd

--- a/roles/dnsdhcp/tasks/main.yml
+++ b/roles/dnsdhcp/tasks/main.yml
@@ -5,5 +5,12 @@
   template: src=roles/dnsdhcp/templates/dnsmasq.conf.j2 dest=/etc/dnsmasq.conf owner=root group=root mode=644 backup=yes
   notify:
     - restart dnsmasq
+- name: manage /etc/resolv.conf
+  lineinfile:
+    path: /etc/resolv.conf
+    create: yes
+    state: present
+    line: "search {{ domain }}"
+- meta: flush_handlers
 - name: start and enable dnsmasq
   service: name=dnsmasq state=started enabled=yes

--- a/roles/dnsdhcp/templates/dnsmasq.conf.j2
+++ b/roles/dnsdhcp/templates/dnsmasq.conf.j2
@@ -1,7 +1,7 @@
-interface={{ lan_interface }}      # Use interface wlan0
+interface={{ lan_interface }}      # Use interface {{ lan_interface }}
 listen-address={{ lan_address }}   # Explicitly specify the address to listen on
 bind-interfaces                    # Bind to the interface to make sure we aren't sending things elsewhere
-server={{upstream_dns_server }}    # Forward DNS requests to this server
+server={{ upstream_dns_server }}    # Forward DNS requests to this server
 domain-needed                      # Don't forward short names
 bogus-priv                         # Never forward addresses in the non-routed address spaces.
-dhcp-range={{ dhcp_range_string }} # Assign IP addresses between 172.24.1.50 and 172.24.1.150 with a 12 hour lease time
+dhcp-range={{ dhcp_range_string }} # DHCP pool and expiry time

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# Pass 'nat_range' and 'upstream_dev' vars to this
 - name: set default foward policy for ufw
   lineinfile:
     path: /etc/default/ufw

--- a/roles/gateway/templates/before.rules.j2
+++ b/roles/gateway/templates/before.rules.j2
@@ -3,7 +3,7 @@
 :POSTROUTING ACCEPT [0:0]
 
 # Forward traffic through eth0 - Change to match you out-interface
--A POSTROUTING -s {{ nat_range }} -o {{ upstream_dev }} -j MASQUERADE
+-A POSTROUTING -s {{ lan_network }} -o {{ wan_interface }} -j MASQUERADE
 
 # don't delete the 'COMMIT' line or these nat table rules won't
 # be processed

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,17 @@
+---
+# Network settings
+wan_interface: enp6s0
+lan_interface: wlp8s0
+lan_address: 172.24.20.1
+lan_netmask: 255.255.255.0
+lan_network: 172.24.20.0/24
+
+# Wifi settings
+ssid: Internet should be free
+channel: 1
+hw_mode: g
+
+# DNS & DHCP settings
+dhcp_range_string: 172.24.20.2,172.24.20.254,1h
+upstream_dns_server: 192.168.1.254
+domain: internetshouldbefree.local


### PR DESCRIPTION
I've updated this. It now includes:
* adblocking via a hosts file
* independence from specific wireless module providers
* WAN side is now DHCP
* more idiomatic Ansible, notably with the `vars/default.yml` file.
* some README.md updates
* compatibility bugfixes; this is now tested with Debian 5 and Debian Testing